### PR TITLE
Add an option to force a sprinkle

### DIFF
--- a/commands/faucet/index.js
+++ b/commands/faucet/index.js
@@ -194,7 +194,7 @@ const sprinkle = async (interaction, options, { redis }) => {
     interaction.ephemeral(
       `Funding ${
         addresses.length > 1 ? `${addresses.length} addresses` : addresses[0]
-      }...`,
+      }...${force ? " (force)" : ""}`,
       { keep: true }
     );
 

--- a/config/default.js
+++ b/config/default.js
@@ -33,6 +33,7 @@ module.exports = {
       ids: ["840931347370737695", "840931856467492885"],
       names: ["swarm-team", "support-team"],
       sprinkles: Infinity,
+      forceSprinkle: true,
     },
   ],
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -18,7 +18,16 @@ const promiseProgress = (promises, progress) => {
   return Promise.all(promises.map((promise) => promise.then(notify)));
 };
 
+const getOption = (options, name) => {
+  for (const option of options) {
+    if (option.name === name) {
+      return option;
+    }
+  }
+};
+
 module.exports = {
   getDuplicates,
   promiseProgress,
+  getOption,
 };


### PR DESCRIPTION
This is mostly useful for when a sprinkle was initiated but failed for some reason (mostly when the bot is restarted), and can also be used for experimenting with postage stamps for example.

Of course, this is only accessible to the support team.