### PR TITLE
Only send 1 gBZZ instead of 10

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -10,7 +10,7 @@ module.exports = {
 
   faucet: {
     sprinkle: {
-      gbzz: 100000000000000000n,
+      gbzz: 10000000000000000n,
       eth: 50000000000000000n,
     },
     launchBlockHeight: 4461700,


### PR DESCRIPTION
This reduces the gBZZ sprinkled by the faucet from 10 to 1 to prepare for the next `bee` release.