### PR TITLE
Increase gas price to 1000 gwei

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -57,7 +57,7 @@ module.exports = {
       maxFundInterval: 60 * 1000, // In ms
       minQueue: 1, // Number of addresses in queue to force a transaction
       maxBatch: 50, // Maximum number of transactions to do at the same time
-      maxGasPrice: 500, // In gwei
+      maxGasPrice: 1000, // In gwei
     },
   },
 


### PR DESCRIPTION
The gas price is currently at 500 gwei or higher, which means that the faucet is stuck.

I increased the limit to 1000, although funds are going to be burned at an alarming rate at this point.